### PR TITLE
Check for ERRORARRAY before checking its length

### DIFF
--- a/src/linode-api.coffee
+++ b/src/linode-api.coffee
@@ -22,7 +22,7 @@ class LinodeClient
       if obj.ERRORARRAY && obj.ERRORARRAY.length > 0
         callback obj.ERRORARRAY[0].ERRORMESSAGE, undefined
       else
-        callback undefined, obj.DATA
+        callback undefined, obj.DATA?obj.DATA:obj
 
 exports.LinodeClient = LinodeClient
 

--- a/src/linode-api.coffee
+++ b/src/linode-api.coffee
@@ -19,7 +19,7 @@ class LinodeClient
     uri = "#{@base_uri}&api_action=#{action}&#{qs.stringify args}"
     request {uri}, (err, res, body) ->
       obj = JSON.parse body
-      if obj.ERRORARRAY.length > 0
+      if obj.ERRORARRAY && obj.ERRORARRAY.length > 0
         callback obj.ERRORARRAY[0].ERRORMESSAGE, undefined
       else
         callback undefined, obj.DATA


### PR DESCRIPTION
If the API client is called with a batch of commands, then
obj.ERRORARRAY does not exist since obj is an array.  We could
deal with the whole batching stuff in linode-api, or just let the
caller deal with it.

In either case, we should be prepared for the case where ERRORARRAY
does not actually exist, so checking its length throws an exception.
