### PR TITLE
Don't crash when Linode returns an invalid JSON

### DIFF
--- a/src/linode-api.coffee
+++ b/src/linode-api.coffee
@@ -18,7 +18,11 @@ class LinodeClient
   call: (action, args, callback) ->
     uri = "#{@base_uri}&api_action=#{action}&#{qs.stringify args}"
     request {uri}, (err, res, body) ->
-      obj = JSON.parse body
+      try
+        obj = JSON.parse body
+      catch e
+        return callback "Linode returned an invalid JSON", undefined
+      
       if obj.ERRORARRAY && obj.ERRORARRAY.length > 0
         callback obj.ERRORARRAY[0].ERRORMESSAGE, undefined
       else


### PR DESCRIPTION
Sometimes, because of 5xx errors, Linode doesn't actually return a JSON, but an error string. That causes linode-api to crash. This patch fixes this by forwarding an invalid JSON error to the callback.

Please notice that I don't actually write in Coffeescript, but the code should be correct (it's equivalent to the change I made locally directly to the .js file to fix this).
